### PR TITLE
Provide better errors when the information fails to load

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,8 +48,8 @@ app.post('/content', async (req, res) => {
 
     res.sendStatus(200)
   } catch (e) {
-    logging.error(`ERROR: ${e.message}`)
-    res.sendStatus(500)
+    logging.error(`ERROR: ${e}`)
+    res.status(500).json(e)
   }
 })
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -14,4 +14,13 @@ body, html {
   padding: 1em;
 }
 
+#something-went-wrong {
+  display: none;
+  background-color: red;
+  border: 1px solid lightcoral;
+  border-radius: 20px;
+  padding: 20px;
+  text-align: center;
+}
+
 /*# sourceMappingURL=index.css.map */

--- a/static/css/index.css.map
+++ b/static/css/index.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../sass/index.scss"],"names":[],"mappings":"AAAA;EACE;EACA;EACA;EACA;;;AAGF;EACE;EAEA;EACA;EACA;EAEA;EACA","file":"index.css"}
+{"version":3,"sourceRoot":"","sources":["../sass/index.scss"],"names":[],"mappings":"AAAA;EACE;EACA;EACA;EACA;;;AAGF;EACE;EAEA;EACA;EACA;EAEA;EACA;;;AAGF;EACE;EACA;EACA;EACA;EACA;EACA","file":"index.css"}

--- a/static/index.html
+++ b/static/index.html
@@ -13,5 +13,9 @@
     <input type="text" name="" id="contenturl">
     <button onclick='handleClick();'>Go</button>
   </div>
+  <div id=something-went-wrong>
+    <h2>Oops! Something went wrong...</h2>
+    <div id=details></div>
+  </div>
 </body>
 </html>

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -2,17 +2,41 @@
 /* eslint-disable no-undef */
 
 async function handleClick (e) {
-  const location = document.querySelector('#contenturl').value
-  const response = await fetch('http://127.0.0.1:8080/content', {
-    method: 'POST',
-    mode: 'cors',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ contentUrl: location })
-  })
+  try {
+    const location = document.querySelector('#contenturl').value
+    const response = await fetch('http://127.0.0.1:8080/content', {
+      method: 'POST',
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ contentUrl: location })
+    })
 
-  if (response.status === 200) {
-    window.location = './terminal.html'
+    if (response.status === 200) {
+      window.location = './terminal.html'
+    }
+
+    // If we get here, we know it's an error
+    if (response.status === 404) {
+      throw new Error('Could not find content')
+    }
+
+    const errorInformation = await response.json()
+
+    if (errorInformation.code === 'ENOTFOUND') {
+      throw new Error(`Looks we couldn't find the host http://${location}, full error was ${JSON.stringify(errorInformation)}`)
+    }
+
+    if (response.status === 500) {
+      throw new Error(JSON.stringify(errorInformation))
+    }
+
+    throw new Error('Something inexplicable happened!')
+  } catch (error) {
+    const errorBox = document.querySelector('#something-went-wrong')
+    const details = document.querySelector('#details')
+    details.innerHTML = error
+    errorBox.style.display = 'block'
   }
 }

--- a/static/sass/index.scss
+++ b/static/sass/index.scss
@@ -16,3 +16,12 @@ body, html {
   padding: 1em;
 }
 
+#something-went-wrong {
+  display: none;
+  background-color: red;
+  border: 1px solid lightcoral;
+  border-radius: 20px;
+  padding: 20px;
+  text-align: center;
+}
+

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -96,13 +96,14 @@ describe('App Tests', () => {
         })
     })
 
-    it('Should return 500 if there is an error during the loading of the content', () => {
+    it('Should return 500 and the error if there is an error during the loading of the content', () => {
       const fetchStub = sinon.stub(fetch, 'Promise').rejects('Bang!')
       return supertest(app)
         .post('/content')
         .send({ contentUrl: 'mockhost.com/content.json' })
         .then(response => {
           expect(response.status).to.equal(500)
+          expect(JSON.parse(response.text)).to.not.equal(undefined)
           fetchStub.restore()
         })
     })


### PR DESCRIPTION
Fixes https://github.com/SamMayWork/chiron-client/issues/8

This PR:
 - Adds a new error box on the index page
 - Passes errors from `/content` back through to the client
 - Adds tests

Errors look like this now:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/25016090/161759798-a43bcbdf-0ddf-4164-8e42-6acf177ea707.png">