### PR TITLE
Change the end page to make more sense

### DIFF
--- a/src/contentEngine.js
+++ b/src/contentEngine.js
@@ -24,7 +24,20 @@ class ContentEngine {
   }
 
   async processNextChunk () {
+    if (this.document.length === 0) {
+      this.currentChunk = {
+        finalChunk: true,
+        text: "<h1>End</h1><p>You've reached the end of this document and have covered all of the content, well done!</p>\n"
+      }
+    }
+
     if (this.completedChunks) {
+      if (this.currentChunk.finalChunk) {
+        this.completedChunks[0].endTime = Date.now()
+        this.state = ENGINE_STATES.DONE
+        return
+      }
+
       this.completedChunks[0].endTime = Date.now()
       this.completedChunks.unshift({
         startTime: Date.now(),

--- a/test/contentEngine-test.js
+++ b/test/contentEngine-test.js
@@ -96,7 +96,7 @@ describe('Content Engine Tests', () => {
       })
     })
 
-    it('Should correctly load complex JSON content and process tbe content', async () => {
+    it('Should correctly load complex JSON content and process the content', async () => {
       const engine = new ContentEngine()
       engine.document = complexTutorial
       await engine.processNextChunk()
@@ -138,6 +138,18 @@ describe('Content Engine Tests', () => {
             value: 'kubectl get deployments'
           }
         ]
+      })
+    })
+
+    it('Should correctly load the final page when the content is finished', async () => {
+      const engine = new ContentEngine()
+      engine.document = JSON.parse(JSON.stringify(simpleTutorial))
+      await engine.processNextChunk()
+      await engine.processNextChunk()
+      expect(engine.currentChunk).to.not.equal(undefined)
+      expect(engine.currentChunk).to.deep.equal({
+        finalChunk: true,
+        text: "<h1>End</h1><p>You've reached the end of this document and have covered all of the content, well done!</p>\n"
       })
     })
   })


### PR DESCRIPTION
Closes https://github.com/SamMayWork/chiron-client/issues/6

Changes the behaviour of the content engine to insert a default chunk when the end of the content has been reached

*Current Default End Page*
<img width="703" alt="image" src="https://user-images.githubusercontent.com/25016090/161766291-44bdf8d2-1e2e-4406-ac09-af947b089211.png">

*History page correct with content*
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/25016090/161766398-1bc986a6-fe2e-44a4-b026-d1d53cef32cb.png">
