### PR TITLE
Fix minor bug where error appears on load

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -15,6 +15,7 @@ async function handleClick (e) {
 
     if (response.status === 200) {
       window.location = './terminal.html'
+      return
     }
 
     // If we get here, we know it's an error


### PR DESCRIPTION
When loading content an error used to appear shortly before being redirected, this was due to the function continuing to the error phase during the redirection, now fixed.