### PR TITLE
Add support for partial string matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 node_modules
 .nyc_output
 coverage
+.DS_Store

--- a/src/contentEngine.js
+++ b/src/contentEngine.js
@@ -134,7 +134,8 @@ class ContentEngine {
 
     if (this.currentChunk.postChecks[0]?.method === 'COMMANDWAIT') {
       logging.debug(`Command is ${command}, looking for ${this.currentChunk.postChecks[0]?.value}`)
-      if (this.currentChunk.postChecks[0]?.value === command) {
+      const commandMatch = this.currentChunk.postChecks[0]?.value.replaceAll('*', '.*')
+      if (command.match(commandMatch)) {
         return shouldProcessNextChunk(this)
       }
     }
@@ -153,7 +154,7 @@ class ContentEngine {
    */
   async meetsResourceRequirements (kind, namespace, value, equalityOperator, name = '', blockUntilTrue = false) {
     while (true) {
-      const resources = await this.kubeChecker.getByResourceType(kind, namespace)
+      let resources = await this.kubeChecker.getByResourceType(kind, namespace)
       logging.info(`Resources responses was: ${JSON.stringify(resources)}`)
 
       let checksMet = true
@@ -165,8 +166,9 @@ class ContentEngine {
       }
 
       if (name && checksMet) {
-        resources.filter(resource => {
-          return resource.includes(name)
+        const matchingString = name.replaceAll('*', '.*')
+        resources = resources.filter(resource => {
+          return resource.match(matchingString) !== null
         })
       }
 

--- a/test/contentEngine-test.js
+++ b/test/contentEngine-test.js
@@ -86,7 +86,7 @@ describe('Content Engine Tests', () => {
           {
             type: 'POSTCHECK',
             method: 'COMMANDWAIT',
-            value: 'ls -al'
+            value: 'ls *'
           },
           {
             type: 'POSTCHECK',
@@ -502,6 +502,14 @@ describe('Content Engine Tests', () => {
       getByResourceTypeStub = sinon.stub(engine.kubeChecker, 'getByResourceType').resolves([])
       const result = await engine.meetsResourceRequirements('POD', 'default', 3, 'EQUALS')
       expect(result).to.equal(false)
+      expect(getByResourceTypeStub.callCount).to.equal(1)
+    })
+
+    it('Should resolve true when using partial matching and there are resources', async () => {
+      getByResourceTypeStub.restore()
+      getByResourceTypeStub = sinon.stub(engine.kubeChecker, 'getByResourceType').resolves(['basic-deployment-a', 'basic-deployment-b', 'something-else-a'])
+      const result = await engine.meetsResourceRequirements('POD', 'default', 2, 'EQUALS', 'basic-*')
+      expect(result).to.equal(true)
       expect(getByResourceTypeStub.callCount).to.equal(1)
     })
   })

--- a/test/samples/simple.json
+++ b/test/samples/simple.json
@@ -15,7 +15,7 @@
         {
             "method": "COMMANDWAIT",
             "type": "POSTCHECK",
-            "value": "ls -al"
+            "value": "ls *"
         },
         {
           "method": "COMMANDWAIT",


### PR DESCRIPTION
Closes https://github.com/SamMayWork/chiron-client/issues/23

This PR now means that COMMANDWAIT commands can use wildcard syntax (*) to match commands that have parameters. Additionally CHECK commands now accept * in the name of the object